### PR TITLE
chore: update readme minimum laravel version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![StyleCI](https://styleci.io/repos/96563589/shield?branch=master)](https://styleci.io/repos/96563589)
 [![Total Downloads](https://img.shields.io/packagist/dt/spatie/laravel-image-optimizer.svg?style=flat-square)](https://packagist.org/packages/spatie/laravel-image-optimizer)
 
-This package is the Laravel 5.4 and up specific integration of [spatie/image-optimizer](https://github.com/spatie/image-optimizer). It can optimize PNGs, JPGs, SVGs and GIFs by running them through a chain of various [image optimization tools](https://github.com/spatie/image-optimizer#optimization-tools). The package will automatically detect which optimization binaries are installed on your system and use them.
+This package is the Laravel 5.7 and up specific integration of [spatie/image-optimizer](https://github.com/spatie/image-optimizer). It can optimize PNGs, JPGs, SVGs and GIFs by running them through a chain of various [image optimization tools](https://github.com/spatie/image-optimizer#optimization-tools). The package will automatically detect which optimization binaries are installed on your system and use them.
 
 Here's how you can use it:
 


### PR DESCRIPTION
As per https://github.com/spatie/laravel-image-optimizer/issues/65 the supported version in the readme is incorrect.

I have updated it as per the current `composer.json` :smile: 	